### PR TITLE
Add User Links admin page for manual Firebase UID → client linking

### DIFF
--- a/functions/src/admin/adminLinkUser.ts
+++ b/functions/src/admin/adminLinkUser.ts
@@ -1,0 +1,128 @@
+/**
+ * @file adminLinkUser.ts
+ * @description Admin-only callable that links a Firebase Auth UID to an existing
+ *              client document (identified by "cid"). This mirrors the logic of
+ *              the mobile app's linkNewUser call so an administrator can finish
+ *              the linking process manually when the mobile app's API call
+ *              failed (leaving the user with a Firebase Auth account but no
+ *              linked client record).
+ */
+
+import * as functions from "firebase-functions/v1";
+import * as admin from "firebase-admin";
+import { checkAdminPermission, getAdminNameByUid } from "../helpers/adminPermissions";
+import { addUidToConnectedUsers } from "../helpers/addUidToConnectedUsers";
+import config from "../../config.json";
+
+interface AdminLinkUserData {
+  uid: string;
+  cid: string;
+}
+
+/**
+ * Callable: adminLinkUser
+ *
+ * Links the given Firebase Auth UID to the client document with the given
+ * CID. Pulls the user's email from Firebase Auth, updates the Firestore
+ * document (setting uid, email, appEmail, linked), and grants access to the
+ * client's connected users. Emulates what the mobile app's linkNewUser
+ * callable is supposed to do, but callable by an admin instead of the user.
+ *
+ * Requires admin-level permissions.
+ */
+export const adminLinkUser = functions.https.onCall(
+  async (data: AdminLinkUserData, context: functions.https.CallableContext) => {
+    checkAdminPermission(context, "admin");
+
+    const { uid, cid } = data || ({} as AdminLinkUserData);
+    if (!uid || !cid) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        'Both "uid" and "cid" are required.'
+      );
+    }
+
+    const usersCollectionID = config.FIRESTORE_ACTIVE_USERS_COLLECTION;
+
+    // Verify the Auth user exists and fetch their email
+    let authUser: admin.auth.UserRecord;
+    try {
+      authUser = await admin.auth().getUser(uid);
+    } catch (error: any) {
+      if (error?.code === "auth/user-not-found") {
+        throw new functions.https.HttpsError(
+          "not-found",
+          `No Firebase Auth user found for uid: ${uid}`
+        );
+      }
+      console.error("Error looking up auth user:", error);
+      throw new functions.https.HttpsError(
+        "internal",
+        "Failed to look up Firebase Auth user"
+      );
+    }
+
+    const email = authUser.email ?? "";
+
+    const firestore = admin.firestore();
+    const usersCollection = firestore.collection(usersCollectionID);
+    const userRef = usersCollection.doc(cid);
+    const userSnapshot = await userRef.get();
+
+    if (!userSnapshot.exists) {
+      throw new functions.https.HttpsError(
+        "not-found",
+        `Client document not found for cid: ${cid}`
+      );
+    }
+
+    const existingData = userSnapshot.data() || {};
+
+    // Block double-linking the same client document
+    if (existingData.uid && existingData.uid !== "" && existingData.uid !== uid) {
+      throw new functions.https.HttpsError(
+        "already-exists",
+        `Client ${cid} is already linked to a different UID.`
+      );
+    }
+
+    // Ensure this UID isn't already linked to a different client document
+    const existingLinkSnap = await usersCollection.where("uid", "==", uid).get();
+    for (const docSnap of existingLinkSnap.docs) {
+      if (docSnap.id !== cid) {
+        throw new functions.https.HttpsError(
+          "already-exists",
+          `UID ${uid} is already linked to client ${docSnap.id}.`
+        );
+      }
+    }
+
+    const updatedBy = await getAdminNameByUid(context.auth!.uid);
+
+    await userRef.set(
+      {
+        ...existingData,
+        uid,
+        email,
+        appEmail: email,
+        linked: true,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedBy,
+      },
+      { merge: true }
+    );
+
+    const connectedUsers: string[] = existingData.connectedUsers || [];
+    await addUidToConnectedUsers(connectedUsers, uid, usersCollection);
+
+    console.log(
+      `Admin ${context.auth!.uid} (${updatedBy}) linked auth uid ${uid} to client ${cid}`
+    );
+
+    return {
+      success: true,
+      message: `Linked UID ${uid} to client ${cid}.`,
+      email,
+    };
+  }
+);

--- a/functions/src/admin/listAuthUsers.ts
+++ b/functions/src/admin/listAuthUsers.ts
@@ -27,6 +27,14 @@ interface AuthUserSummary {
   isAdmin: boolean;
 }
 
+interface UnlinkedClientSummary {
+  cid: string;
+  firstName: string;
+  lastName: string;
+  companyName: string;
+  email: string;
+}
+
 /**
  * Callable: listAuthUsers
  *
@@ -44,22 +52,40 @@ export const listAuthUsers = functions.https.onCall(
       const usersCollectionID = config.FIRESTORE_ACTIVE_USERS_COLLECTION;
       const firestore = admin.firestore();
 
-      // Build a lookup from uid -> client document info for all linked clients.
-      // We fetch the full collection and filter in memory because some docs may
-      // not have the `uid` field at all, which a Firestore != query cannot match.
+      // Single pass over the clients collection to build both:
+      // 1. A uid -> client lookup for already-linked clients.
+      // 2. The list of unlinked clients (sent back so the page doesn't have to
+      //    issue a second, heavier client fetch on the frontend).
       const linkedUidToClient = new Map<string, { cid: string; name: string }>();
+      const unlinkedClients: UnlinkedClientSummary[] = [];
       const clientsSnapshot = await firestore.collection(usersCollectionID).get();
 
       for (const docSnap of clientsSnapshot.docs) {
         const data = docSnap.data() || {};
-        const uid: string | undefined = data.uid;
-        if (!uid || uid === "") continue;
-        const first = data?.name?.first ?? "";
-        const last = data?.name?.last ?? "";
-        const company = data?.name?.company ?? "";
+        const first: string = data?.name?.first ?? "";
+        const last: string = data?.name?.last ?? "";
+        const company: string = data?.name?.company ?? "";
         const displayName = [first, last].filter(Boolean).join(" ") || company || "";
-        linkedUidToClient.set(uid, { cid: docSnap.id, name: displayName });
+        const uid: string | undefined = data.uid;
+
+        if (uid && uid !== "") {
+          linkedUidToClient.set(uid, { cid: docSnap.id, name: displayName });
+        } else {
+          unlinkedClients.push({
+            cid: docSnap.id,
+            firstName: first,
+            lastName: last,
+            companyName: company,
+            email: data?.initEmail ?? data?.email ?? "",
+          });
+        }
       }
+
+      unlinkedClients.sort((a, b) => {
+        const an = `${a.firstName} ${a.lastName} ${a.companyName}`.toLowerCase();
+        const bn = `${b.firstName} ${b.lastName} ${b.companyName}`.toLowerCase();
+        return an.localeCompare(bn);
+      });
 
       // Collect admin UIDs so we can flag them in the UI
       const adminUids = new Set<string>();
@@ -93,7 +119,7 @@ export const listAuthUsers = functions.https.onCall(
         pageToken = result.pageToken;
       } while (pageToken);
 
-      return { success: true, users };
+      return { success: true, users, unlinkedClients };
     } catch (error) {
       console.error("Error listing auth users:", error);
       if (error instanceof functions.https.HttpsError) {

--- a/functions/src/admin/listAuthUsers.ts
+++ b/functions/src/admin/listAuthUsers.ts
@@ -1,0 +1,108 @@
+/**
+ * @file listAuthUsers.ts
+ * @description Admin-only callable function that lists all Firebase Auth users along
+ *              with whether they are currently linked to a client document in
+ *              Firestore. Used to diagnose and resolve cases where an auth user
+ *              was created during mobile sign-up but the corresponding client
+ *              link call never succeeded.
+ */
+
+import * as functions from "firebase-functions/v1";
+import * as admin from "firebase-admin";
+import { checkAdminPermission } from "../helpers/adminPermissions";
+import config from "../../config.json";
+
+interface AuthUserSummary {
+  uid: string;
+  email: string | null;
+  displayName: string | null;
+  phoneNumber: string | null;
+  providerIds: string[];
+  disabled: boolean;
+  emailVerified: boolean;
+  creationTime: string | null;
+  lastSignInTime: string | null;
+  linkedCid: string | null;
+  linkedClientName: string | null;
+  isAdmin: boolean;
+}
+
+/**
+ * Callable: listAuthUsers
+ *
+ * Returns every user in Firebase Authentication along with metadata indicating
+ * whether that UID is already linked to a client document in the configured
+ * users collection, or belongs to an admin account.
+ *
+ * Requires admin-level permissions.
+ */
+export const listAuthUsers = functions.https.onCall(
+  async (_data: unknown, context: functions.https.CallableContext) => {
+    checkAdminPermission(context, "admin");
+
+    try {
+      const usersCollectionID = config.FIRESTORE_ACTIVE_USERS_COLLECTION;
+      const firestore = admin.firestore();
+
+      // Build a lookup from uid -> client document info for all linked clients.
+      // We fetch the full collection and filter in memory because some docs may
+      // not have the `uid` field at all, which a Firestore != query cannot match.
+      const linkedUidToClient = new Map<string, { cid: string; name: string }>();
+      const clientsSnapshot = await firestore.collection(usersCollectionID).get();
+
+      for (const docSnap of clientsSnapshot.docs) {
+        const data = docSnap.data() || {};
+        const uid: string | undefined = data.uid;
+        if (!uid || uid === "") continue;
+        const first = data?.name?.first ?? "";
+        const last = data?.name?.last ?? "";
+        const company = data?.name?.company ?? "";
+        const displayName = [first, last].filter(Boolean).join(" ") || company || "";
+        linkedUidToClient.set(uid, { cid: docSnap.id, name: displayName });
+      }
+
+      // Collect admin UIDs so we can flag them in the UI
+      const adminUids = new Set<string>();
+      const adminsSnapshot = await firestore.collection("admins").get();
+      for (const docSnap of adminsSnapshot.docs) {
+        adminUids.add(docSnap.id);
+      }
+
+      // Page through all Firebase Auth users (Admin SDK returns up to 1000 per call)
+      const users: AuthUserSummary[] = [];
+      let pageToken: string | undefined = undefined;
+      do {
+        const result = await admin.auth().listUsers(1000, pageToken);
+        for (const user of result.users) {
+          const linked = linkedUidToClient.get(user.uid);
+          users.push({
+            uid: user.uid,
+            email: user.email ?? null,
+            displayName: user.displayName ?? null,
+            phoneNumber: user.phoneNumber ?? null,
+            providerIds: user.providerData.map((p) => p.providerId),
+            disabled: user.disabled,
+            emailVerified: user.emailVerified,
+            creationTime: user.metadata?.creationTime ?? null,
+            lastSignInTime: user.metadata?.lastSignInTime ?? null,
+            linkedCid: linked?.cid ?? null,
+            linkedClientName: linked?.name ?? null,
+            isAdmin: adminUids.has(user.uid),
+          });
+        }
+        pageToken = result.pageToken;
+      } while (pageToken);
+
+      return { success: true, users };
+    } catch (error) {
+      console.error("Error listing auth users:", error);
+      if (error instanceof functions.https.HttpsError) {
+        throw error;
+      }
+      throw new functions.https.HttpsError(
+        "internal",
+        "Failed to list Firebase Auth users"
+      );
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,6 +34,8 @@ import { createAdminAccount } from "./admin/createAdminAccount";
 import { updateAdminPermissions } from "./admin/updateAdminPermissions";
 import { getAllAdmins } from "./admin/getAllAdmins";
 import { deleteAdmin } from "./admin/deleteAdmin";
+import { listAuthUsers } from "./admin/listAuthUsers";
+import { adminLinkUser } from "./admin/adminLinkUser";
 
 export {
   // ======= TRIGGERS =======
@@ -66,4 +68,6 @@ export {
   updateAdminPermissions,
   getAllAdmins,
   deleteAdmin,
+  listAuthUsers,
+  adminLinkUser,
 }

--- a/src/_nav.tsx
+++ b/src/_nav.tsx
@@ -64,8 +64,8 @@ const _nav: NavItem[] = [
   },
   {
     component: CNavItem,
-    name: "User Links",
-    to: '/user-links',
+    name: "User Authentication",
+    to: '/user-authentication',
     icon: <CIcon icon={cilLinkAlt} customClassName="nav-icon" />,
   },
   {

--- a/src/_nav.tsx
+++ b/src/_nav.tsx
@@ -12,6 +12,7 @@ import {
   cilFolderOpen,
   cilGrid,
   cilLayers,
+  cilLinkAlt,
   cilMap,
   cilNotes,
   cilPencil,
@@ -60,6 +61,12 @@ const _nav: NavItem[] = [
     name: "Statements",
     to: '/statements',
     icon: <CIcon icon={cilFolderOpen} customClassName="nav-icon" />,
+  },
+  {
+    component: CNavItem,
+    name: "User Links",
+    to: '/user-links',
+    icon: <CIcon icon={cilLinkAlt} customClassName="nav-icon" />,
   },
   {
     component: CNavItem,

--- a/src/components/ConditionalNav.tsx
+++ b/src/components/ConditionalNav.tsx
@@ -2,6 +2,7 @@ import CIcon from '@coreui/icons-react'
 import {
   cilFolderOpen,
   cilLayers,
+  cilLinkAlt,
   cilPeople,
   cilSpeedometer,
 } from '@coreui/icons'
@@ -38,8 +39,14 @@ export const useConditionalNav = (): NavItem[] => {
     },
   ]
 
-  // Add Admin Management tab only for users with admin permissions
+  // Admin-only tabs
   if (isAdmin) {
+    baseNav.push({
+      component: CNavItem,
+      name: "User Links",
+      to: '/user-links',
+      icon: <CIcon icon={cilLinkAlt} customClassName="nav-icon" />,
+    })
     baseNav.push({
       component: CNavItem,
       name: "Admin Management",

--- a/src/components/ConditionalNav.tsx
+++ b/src/components/ConditionalNav.tsx
@@ -43,8 +43,8 @@ export const useConditionalNav = (): NavItem[] => {
   if (isAdmin) {
     baseNav.push({
       component: CNavItem,
-      name: "User Links",
-      to: '/user-links',
+      name: "User Authentication",
+      to: '/user-authentication',
       icon: <CIcon icon={cilLinkAlt} customClassName="nav-icon" />,
     })
     baseNav.push({

--- a/src/db/adminService.ts
+++ b/src/db/adminService.ts
@@ -21,6 +21,21 @@ export interface AdminClaims {
   adminPermissions: AdminPermission
 }
 
+export interface AuthUserSummary {
+  uid: string
+  email: string | null
+  displayName: string | null
+  phoneNumber: string | null
+  providerIds: string[]
+  disabled: boolean
+  emailVerified: boolean
+  creationTime: string | null
+  lastSignInTime: string | null
+  linkedCid: string | null
+  linkedClientName: string | null
+  isAdmin: boolean
+}
+
 export class AdminService {
   private db: Firestore = getFirestore(app)
   private adminsCollection: CollectionReference<DocumentData, DocumentData>
@@ -176,6 +191,35 @@ export class AdminService {
       console.error('Error deleting admin:', error)
       throw error
     }
+  }
+
+  /**
+   * Get all Firebase Auth users with their linking status against the clients
+   * collection. Requires 'admin' custom claim.
+   */
+  async listAuthUsers(): Promise<AuthUserSummary[]> {
+    const listAuthUsersFn = httpsCallable(this.functions, 'listAuthUsers')
+    const result = await listAuthUsersFn()
+    const data = result.data as { success: boolean, users: AuthUserSummary[] }
+    if (!data.success) {
+      throw new Error('Failed to fetch Firebase Auth users')
+    }
+    return data.users
+  }
+
+  /**
+   * Link a Firebase Auth UID to a client document (by CID). Requires 'admin'
+   * custom claim. Mirrors the mobile app's linkNewUser flow so an
+   * administrator can manually finish a failed link.
+   */
+  async linkAuthUserToClient(uid: string, cid: string): Promise<{ email: string }> {
+    const linkFn = httpsCallable(this.functions, 'adminLinkUser')
+    const result = await linkFn({ uid, cid })
+    const data = result.data as { success: boolean, message: string, email: string }
+    if (!data.success) {
+      throw new Error(data.message || 'Failed to link user')
+    }
+    return { email: data.email }
   }
 
   /**

--- a/src/db/adminService.ts
+++ b/src/db/adminService.ts
@@ -36,6 +36,14 @@ export interface AuthUserSummary {
   isAdmin: boolean
 }
 
+export interface UnlinkedClientSummary {
+  cid: string
+  firstName: string
+  lastName: string
+  companyName: string
+  email: string
+}
+
 export class AdminService {
   private db: Firestore = getFirestore(app)
   private adminsCollection: CollectionReference<DocumentData, DocumentData>
@@ -197,14 +205,21 @@ export class AdminService {
    * Get all Firebase Auth users with their linking status against the clients
    * collection. Requires 'admin' custom claim.
    */
-  async listAuthUsers(): Promise<AuthUserSummary[]> {
+  async listAuthUsers(): Promise<{ users: AuthUserSummary[]; unlinkedClients: UnlinkedClientSummary[] }> {
     const listAuthUsersFn = httpsCallable(this.functions, 'listAuthUsers')
     const result = await listAuthUsersFn()
-    const data = result.data as { success: boolean, users: AuthUserSummary[] }
+    const data = result.data as {
+      success: boolean
+      users: AuthUserSummary[]
+      unlinkedClients?: UnlinkedClientSummary[]
+    }
     if (!data.success) {
       throw new Error('Failed to fetch Firebase Auth users')
     }
-    return data.users
+    return {
+      users: data.users || [],
+      unlinkedClients: data.unlinkedClients || [],
+    }
   }
 
   /**

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,7 +13,7 @@ const Activities = React.lazy(() => import('./views/activities/Activities'))
 const Dashboard = React.lazy(() => import('./views/dashboard/Dashboard'))
 const Statements = React.lazy(() => import('./views/statements/Statements'))
 const AdminManagement = React.lazy(() => import('./views/admin/AdminManagement'))
-const UserLinks = React.lazy(() => import('./views/admin/UserLinks'))
+const UserAuthentication = React.lazy(() => import('./views/admin/UserAuthentication'))
 
 const routes: Route[] = [
   { path: '/', exact: true, name: <Translation>{(t) => t('home')}</Translation> },
@@ -33,9 +33,9 @@ const routes: Route[] = [
     element: Statements,
   },
   {
-    path: '/user-links',
-    name: 'User Links',
-    element: UserLinks,
+    path: '/user-authentication',
+    name: 'User Authentication',
+    element: UserAuthentication,
   },
   {
     path: '/admin-management',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,6 +13,7 @@ const Activities = React.lazy(() => import('./views/activities/Activities'))
 const Dashboard = React.lazy(() => import('./views/dashboard/Dashboard'))
 const Statements = React.lazy(() => import('./views/statements/Statements'))
 const AdminManagement = React.lazy(() => import('./views/admin/AdminManagement'))
+const UserLinks = React.lazy(() => import('./views/admin/UserLinks'))
 
 const routes: Route[] = [
   { path: '/', exact: true, name: <Translation>{(t) => t('home')}</Translation> },
@@ -30,6 +31,11 @@ const routes: Route[] = [
     path: '/statements',
     name: <Translation>{(t) => t('statements')}</Translation>,
     element: Statements,
+  },
+  {
+    path: '/user-links',
+    name: 'User Links',
+    element: UserLinks,
   },
   {
     path: '/admin-management',

--- a/src/views/admin/UserAuthentication.tsx
+++ b/src/views/admin/UserAuthentication.tsx
@@ -50,7 +50,7 @@ const buildClientLabel = (c: UnlinkedClientSummary): string => {
   return `${name} — ${c.cid}${emailPart}`
 }
 
-const UserLinks: React.FC = () => {
+const UserAuthentication: React.FC = () => {
   const { isAdmin, loading: permissionLoading, adminService } = usePermissions()
 
   const [loading, setLoading] = useState(true)
@@ -238,7 +238,7 @@ const UserLinks: React.FC = () => {
           <CCardHeader>
             <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
               <div>
-                <h4 className="mb-0">User Links</h4>
+                <h4 className="mb-0">User Authentication</h4>
                 <small className="text-muted">
                   Firebase Auth users and their link status with client records. Use this to
                   manually complete a link when the mobile app&rsquo;s sign-up call failed.
@@ -474,4 +474,4 @@ const UserLinks: React.FC = () => {
   )
 }
 
-export default UserLinks
+export default UserAuthentication

--- a/src/views/admin/UserLinks.tsx
+++ b/src/views/admin/UserLinks.tsx
@@ -17,16 +17,16 @@ import {
   CModalFooter,
   CModalHeader,
   CModalTitle,
+  CMultiSelect,
   CRow,
   CSmartTable,
   CSpinner,
 } from '@coreui/react-pro'
+import type { Option } from '@coreui/react-pro/dist/esm/components/multi-select/types'
 import CIcon from '@coreui/icons-react'
 import { cilCheckCircle, cilLinkAlt, cilXCircle } from '@coreui/icons'
 import { usePermissions } from '../../contexts/PermissionContext'
-import { AuthUserSummary } from '../../db/adminService'
-import { DatabaseService } from '../../db/database'
-import { Client } from '../../db/models'
+import { AuthUserSummary, UnlinkedClientSummary } from '../../db/adminService'
 
 type FilterMode = 'all' | 'unlinked' | 'linked' | 'admins'
 
@@ -37,12 +37,18 @@ const formatDate = (value: string | null): string => {
   return d.toLocaleString()
 }
 
+const buildClientLabel = (c: UnlinkedClientSummary): string => {
+  const name = [c.firstName, c.lastName].filter(Boolean).join(' ') || c.companyName || 'Unnamed'
+  const emailPart = c.email ? ` (${c.email})` : ''
+  return `${name} — ${c.cid}${emailPart}`
+}
+
 const UserLinks: React.FC = () => {
   const { isAdmin, loading: permissionLoading, adminService } = usePermissions()
 
   const [loading, setLoading] = useState(true)
   const [users, setUsers] = useState<AuthUserSummary[]>([])
-  const [clients, setClients] = useState<Client[]>([])
+  const [unlinkedClients, setUnlinkedClients] = useState<UnlinkedClientSummary[]>([])
   const [filter, setFilter] = useState<FilterMode>('unlinked')
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
@@ -53,17 +59,16 @@ const UserLinks: React.FC = () => {
   const [manualCid, setManualCid] = useState('')
   const [linkLoading, setLinkLoading] = useState(false)
   const [modalError, setModalError] = useState('')
+  const [selectKey, setSelectKey] = useState(0)
 
   const loadData = async () => {
     try {
       setLoading(true)
       setError('')
-      const [fetchedUsers, fetchedClients] = await Promise.all([
-        adminService.listAuthUsers(),
-        new DatabaseService().getClients(),
-      ])
+      const { users: fetchedUsers, unlinkedClients: fetchedUnlinkedClients } =
+        await adminService.listAuthUsers()
       setUsers(fetchedUsers)
-      setClients((fetchedClients || []) as Client[])
+      setUnlinkedClients(fetchedUnlinkedClients)
     } catch (err: any) {
       console.error('Error loading user links data:', err)
       setError(err?.message || 'Failed to load Firebase Auth users')
@@ -92,22 +97,23 @@ const UserLinks: React.FC = () => {
     }
   }, [users, filter])
 
-  const unlinkedClients = useMemo(
-    () => clients.filter((c) => !c.uid || c.uid === ''),
-    [clients],
+  const baseClientOptions = useMemo<Option[]>(
+    () =>
+      unlinkedClients.map((c) => ({
+        value: c.cid,
+        label: buildClientLabel(c),
+      })),
+    [unlinkedClients],
   )
 
-  const clientOptions = useMemo(() => {
-    const sorted = [...unlinkedClients].sort((a, b) => {
-      const an = `${a.firstName} ${a.lastName}`.toLowerCase()
-      const bn = `${b.firstName} ${b.lastName}`.toLowerCase()
-      return an.localeCompare(bn)
-    })
-    return sorted.map((c) => ({
-      value: c.cid,
-      label: `${c.cid} — ${c.firstName} ${c.lastName}${c.initEmail ? ` (${c.initEmail})` : ''}`,
-    }))
-  }, [unlinkedClients])
+  const clientOptions = useMemo<Option[]>(
+    () =>
+      baseClientOptions.map((opt) => ({
+        ...opt,
+        selected: opt.value === selectedCid,
+      })),
+    [baseClientOptions, selectedCid],
+  )
 
   const handleOpenLinkModal = (user: AuthUserSummary) => {
     setActiveUser(user)
@@ -115,6 +121,7 @@ const UserLinks: React.FC = () => {
     setManualCid('')
     setModalError('')
     setShowLinkModal(true)
+    setSelectKey((k) => k + 1)
   }
 
   const handleConfirmLink = async () => {
@@ -360,23 +367,24 @@ const UserLinks: React.FC = () => {
 
           <div className="mb-3">
             <label className="form-label fw-semibold mb-1">
-              Select an unlinked client
+              Search and select an unlinked client
             </label>
-            <CFormSelect
-              value={selectedCid}
-              onChange={(e) => {
-                setSelectedCid(e.target.value)
-                if (e.target.value) setManualCid('')
-              }}
+            <CMultiSelect
+              key={selectKey}
+              options={clientOptions}
+              multiple={false}
+              cleaner
+              search
+              virtualScroller
+              placeholder="Type a name, email, or CID to search..."
+              searchNoResultsLabel="No matching clients"
               disabled={linkLoading}
-            >
-              <option value="">-- Choose a client --</option>
-              {clientOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </CFormSelect>
+              onChange={(selected) => {
+                const value = (selected[0]?.value as string | undefined) ?? ''
+                setSelectedCid(value)
+                if (value) setManualCid('')
+              }}
+            />
             <small className="text-muted">
               Showing {clientOptions.length} client record
               {clientOptions.length === 1 ? '' : 's'} without a linked UID.

--- a/src/views/admin/UserLinks.tsx
+++ b/src/views/admin/UserLinks.tsx
@@ -25,6 +25,9 @@ import {
 import type { Option } from '@coreui/react-pro/dist/esm/components/multi-select/types'
 import CIcon from '@coreui/icons-react'
 import { cilCheckCircle, cilLinkAlt, cilXCircle } from '@coreui/icons'
+import { collection, getDocs, getFirestore } from 'firebase/firestore'
+import { app } from '../../App'
+import config from '../../../config.json'
 import { usePermissions } from '../../contexts/PermissionContext'
 import { AuthUserSummary, UnlinkedClientSummary } from '../../db/adminService'
 
@@ -61,14 +64,46 @@ const UserLinks: React.FC = () => {
   const [modalError, setModalError] = useState('')
   const [selectKey, setSelectKey] = useState(0)
 
+  const fetchUnlinkedClientsDirect = async (): Promise<UnlinkedClientSummary[]> => {
+    const db = getFirestore(app)
+    const snap = await getDocs(collection(db, config.FIRESTORE_ACTIVE_USERS_COLLECTION))
+    const out: UnlinkedClientSummary[] = []
+    snap.forEach((docSnap) => {
+      const data = docSnap.data() || {}
+      const uid = (data.uid as string | undefined) ?? ''
+      if (uid && uid !== '') return
+      out.push({
+        cid: docSnap.id,
+        firstName: data?.name?.first ?? '',
+        lastName: data?.name?.last ?? '',
+        companyName: data?.name?.company ?? '',
+        email: data?.initEmail ?? data?.email ?? '',
+      })
+    })
+    out.sort((a, b) => {
+      const an = `${a.firstName} ${a.lastName} ${a.companyName}`.toLowerCase()
+      const bn = `${b.firstName} ${b.lastName} ${b.companyName}`.toLowerCase()
+      return an.localeCompare(bn)
+    })
+    return out
+  }
+
   const loadData = async () => {
     try {
       setLoading(true)
       setError('')
-      const { users: fetchedUsers, unlinkedClients: fetchedUnlinkedClients } =
-        await adminService.listAuthUsers()
-      setUsers(fetchedUsers)
-      setUnlinkedClients(fetchedUnlinkedClients)
+      // Run auth-user lookup and the unlinked-client read in parallel. We pull
+      // the client list directly from Firestore so the page works even before
+      // the cloud function is updated to include `unlinkedClients` in its
+      // response (and to avoid waiting on the function's listUsers pagination).
+      const [authResult, directClients] = await Promise.all([
+        adminService.listAuthUsers(),
+        fetchUnlinkedClientsDirect(),
+      ])
+      setUsers(authResult.users)
+      setUnlinkedClients(
+        authResult.unlinkedClients.length > 0 ? authResult.unlinkedClients : directClients,
+      )
     } catch (err: any) {
       console.error('Error loading user links data:', err)
       setError(err?.message || 'Failed to load Firebase Auth users')

--- a/src/views/admin/UserLinks.tsx
+++ b/src/views/admin/UserLinks.tsx
@@ -33,11 +33,15 @@ import { AuthUserSummary, UnlinkedClientSummary } from '../../db/adminService'
 
 type FilterMode = 'all' | 'unlinked' | 'linked' | 'admins'
 
-const formatDate = (value: string | null): string => {
+const parseTimestamp = (value: string | null): number => {
+  if (!value) return 0
+  const t = new Date(value).getTime()
+  return isNaN(t) ? 0 : t
+}
+
+const formatTimestamp = (value: number): string => {
   if (!value) return '-'
-  const d = new Date(value)
-  if (isNaN(d.getTime())) return '-'
-  return d.toLocaleString()
+  return new Date(value).toLocaleString()
 }
 
 const buildClientLabel = (c: UnlinkedClientSummary): string => {
@@ -221,6 +225,8 @@ const UserLinks: React.FC = () => {
   const items = filteredUsers.map((u) => ({
     ...u,
     _linkedLabel: u.linkedClientName || '',
+    creationTime: parseTimestamp(u.creationTime),
+    lastSignInTime: parseTimestamp(u.lastSignInTime),
   }))
 
   const activeUserLinked = !!activeUser?.linkedCid
@@ -331,14 +337,14 @@ const UserLinks: React.FC = () => {
                         : item.providerIds.join(', ')}
                     </td>
                   ),
-                  creationTime: (item: AuthUserSummary) => (
+                  creationTime: (item: AuthUserSummary & { creationTime: number }) => (
                     <td>
-                      <small>{formatDate(item.creationTime)}</small>
+                      <small>{formatTimestamp(item.creationTime)}</small>
                     </td>
                   ),
-                  lastSignInTime: (item: AuthUserSummary) => (
+                  lastSignInTime: (item: AuthUserSummary & { lastSignInTime: number }) => (
                     <td>
-                      <small>{formatDate(item.lastSignInTime)}</small>
+                      <small>{formatTimestamp(item.lastSignInTime)}</small>
                     </td>
                   ),
                   actions: (item: AuthUserSummary) => (

--- a/src/views/admin/UserLinks.tsx
+++ b/src/views/admin/UserLinks.tsx
@@ -1,0 +1,428 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  CAlert,
+  CBadge,
+  CButton,
+  CCard,
+  CCardBody,
+  CCardHeader,
+  CCol,
+  CFormInput,
+  CFormSelect,
+  CInputGroup,
+  CInputGroupText,
+  CLoadingButton,
+  CModal,
+  CModalBody,
+  CModalFooter,
+  CModalHeader,
+  CModalTitle,
+  CRow,
+  CSmartTable,
+  CSpinner,
+} from '@coreui/react-pro'
+import CIcon from '@coreui/icons-react'
+import { cilCheckCircle, cilLinkAlt, cilXCircle } from '@coreui/icons'
+import { usePermissions } from '../../contexts/PermissionContext'
+import { AuthUserSummary } from '../../db/adminService'
+import { DatabaseService } from '../../db/database'
+import { Client } from '../../db/models'
+
+type FilterMode = 'all' | 'unlinked' | 'linked' | 'admins'
+
+const formatDate = (value: string | null): string => {
+  if (!value) return '-'
+  const d = new Date(value)
+  if (isNaN(d.getTime())) return '-'
+  return d.toLocaleString()
+}
+
+const UserLinks: React.FC = () => {
+  const { isAdmin, loading: permissionLoading, adminService } = usePermissions()
+
+  const [loading, setLoading] = useState(true)
+  const [users, setUsers] = useState<AuthUserSummary[]>([])
+  const [clients, setClients] = useState<Client[]>([])
+  const [filter, setFilter] = useState<FilterMode>('unlinked')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const [showLinkModal, setShowLinkModal] = useState(false)
+  const [activeUser, setActiveUser] = useState<AuthUserSummary | null>(null)
+  const [selectedCid, setSelectedCid] = useState('')
+  const [manualCid, setManualCid] = useState('')
+  const [linkLoading, setLinkLoading] = useState(false)
+  const [modalError, setModalError] = useState('')
+
+  const loadData = async () => {
+    try {
+      setLoading(true)
+      setError('')
+      const [fetchedUsers, fetchedClients] = await Promise.all([
+        adminService.listAuthUsers(),
+        new DatabaseService().getClients(),
+      ])
+      setUsers(fetchedUsers)
+      setClients((fetchedClients || []) as Client[])
+    } catch (err: any) {
+      console.error('Error loading user links data:', err)
+      setError(err?.message || 'Failed to load Firebase Auth users')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadData()
+    }
+  }, [isAdmin])
+
+  const filteredUsers = useMemo(() => {
+    switch (filter) {
+      case 'unlinked':
+        return users.filter((u) => !u.linkedCid && !u.isAdmin)
+      case 'linked':
+        return users.filter((u) => !!u.linkedCid)
+      case 'admins':
+        return users.filter((u) => u.isAdmin)
+      case 'all':
+      default:
+        return users
+    }
+  }, [users, filter])
+
+  const unlinkedClients = useMemo(
+    () => clients.filter((c) => !c.uid || c.uid === ''),
+    [clients],
+  )
+
+  const clientOptions = useMemo(() => {
+    const sorted = [...unlinkedClients].sort((a, b) => {
+      const an = `${a.firstName} ${a.lastName}`.toLowerCase()
+      const bn = `${b.firstName} ${b.lastName}`.toLowerCase()
+      return an.localeCompare(bn)
+    })
+    return sorted.map((c) => ({
+      value: c.cid,
+      label: `${c.cid} — ${c.firstName} ${c.lastName}${c.initEmail ? ` (${c.initEmail})` : ''}`,
+    }))
+  }, [unlinkedClients])
+
+  const handleOpenLinkModal = (user: AuthUserSummary) => {
+    setActiveUser(user)
+    setSelectedCid('')
+    setManualCid('')
+    setModalError('')
+    setShowLinkModal(true)
+  }
+
+  const handleConfirmLink = async () => {
+    if (!activeUser) return
+    const cid = (manualCid.trim() || selectedCid).trim()
+    if (!cid) {
+      setModalError('Please select a client or enter a client ID.')
+      return
+    }
+
+    setLinkLoading(true)
+    setModalError('')
+    try {
+      await adminService.linkAuthUserToClient(activeUser.uid, cid)
+      setSuccess(`Linked UID ${activeUser.uid} to client ${cid}.`)
+      setShowLinkModal(false)
+      setActiveUser(null)
+      await loadData()
+    } catch (err: any) {
+      console.error('Error linking user:', err)
+      const message =
+        err?.message?.replace(/^FirebaseError:\s*/, '') ||
+        'Failed to link this UID to that client.'
+      setModalError(message)
+    } finally {
+      setLinkLoading(false)
+    }
+  }
+
+  if (permissionLoading) {
+    return (
+      <div className="text-center mt-5">
+        <CSpinner color="primary" />
+        <p className="mt-3 text-muted">Loading...</p>
+      </div>
+    )
+  }
+
+  if (!isAdmin) {
+    return (
+      <CRow>
+        <CCol xs={12}>
+          <CAlert color="danger">
+            <h4>Access Denied</h4>
+            <p>You need admin permissions to access this page.</p>
+          </CAlert>
+        </CCol>
+      </CRow>
+    )
+  }
+
+  const columns = [
+    { key: 'status', label: 'Status', _style: { width: '10%' }, filter: false, sorter: false },
+    { key: 'uid', label: 'Firebase UID', _style: { width: '22%' } },
+    { key: 'email', label: 'Email' },
+    { key: 'providers', label: 'Providers', _style: { width: '10%' }, filter: false },
+    { key: 'creationTime', label: 'Created', _style: { width: '12%' }, filter: false },
+    { key: 'lastSignInTime', label: 'Last Sign-In', _style: { width: '12%' }, filter: false },
+    { key: 'actions', label: '', _style: { width: '10%' }, filter: false, sorter: false },
+  ]
+
+  const items = filteredUsers.map((u) => ({
+    ...u,
+    _linkedLabel: u.linkedClientName || '',
+  }))
+
+  const activeUserLinked = !!activeUser?.linkedCid
+
+  return (
+    <CRow>
+      <CCol xs={12}>
+        <CCard>
+          <CCardHeader>
+            <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
+              <div>
+                <h4 className="mb-0">User Links</h4>
+                <small className="text-muted">
+                  Firebase Auth users and their link status with client records. Use this to
+                  manually complete a link when the mobile app&rsquo;s sign-up call failed.
+                </small>
+              </div>
+              <div className="d-flex align-items-center gap-2">
+                <CFormSelect
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value as FilterMode)}
+                  style={{ minWidth: '180px' }}
+                >
+                  <option value="unlinked">Unlinked only</option>
+                  <option value="linked">Linked clients</option>
+                  <option value="admins">Admins</option>
+                  <option value="all">All users</option>
+                </CFormSelect>
+                <CButton color="secondary" variant="outline" onClick={loadData} disabled={loading}>
+                  Refresh
+                </CButton>
+              </div>
+            </div>
+          </CCardHeader>
+          <CCardBody>
+            {error && (
+              <CAlert color="danger" dismissible onClose={() => setError('')}>
+                {error}
+              </CAlert>
+            )}
+            {success && (
+              <CAlert color="success" dismissible onClose={() => setSuccess('')}>
+                {success}
+              </CAlert>
+            )}
+
+            {loading ? (
+              <div className="text-center py-4">
+                <CSpinner color="primary" />
+              </div>
+            ) : (
+              <CSmartTable
+                activePage={1}
+                cleaner
+                columns={columns}
+                columnFilter
+                columnSorter
+                items={items}
+                itemsPerPage={25}
+                itemsPerPageSelect
+                pagination
+                sorterValue={{ column: 'creationTime', state: 'desc' }}
+                scopedColumns={{
+                  status: (item: AuthUserSummary) => (
+                    <td>
+                      {item.isAdmin ? (
+                        <CBadge color="info">Admin</CBadge>
+                      ) : item.linkedCid ? (
+                        <CBadge color="success">
+                          <CIcon icon={cilCheckCircle} className="me-1" />
+                          Linked
+                        </CBadge>
+                      ) : (
+                        <CBadge color="warning">
+                          <CIcon icon={cilXCircle} className="me-1" />
+                          Unlinked
+                        </CBadge>
+                      )}
+                    </td>
+                  ),
+                  uid: (item: AuthUserSummary) => (
+                    <td>
+                      <code style={{ fontSize: '0.85em' }}>{item.uid}</code>
+                      {item.linkedCid && (
+                        <div>
+                          <small className="text-muted">
+                            Client {item.linkedCid}
+                            {item.linkedClientName ? ` · ${item.linkedClientName}` : ''}
+                          </small>
+                        </div>
+                      )}
+                    </td>
+                  ),
+                  email: (item: AuthUserSummary) => (
+                    <td>
+                      {item.email || <span className="text-muted">No email</span>}
+                      {item.displayName && (
+                        <div>
+                          <small className="text-muted">{item.displayName}</small>
+                        </div>
+                      )}
+                    </td>
+                  ),
+                  providers: (item: AuthUserSummary) => (
+                    <td>
+                      {item.providerIds.length === 0
+                        ? '-'
+                        : item.providerIds.join(', ')}
+                    </td>
+                  ),
+                  creationTime: (item: AuthUserSummary) => (
+                    <td>
+                      <small>{formatDate(item.creationTime)}</small>
+                    </td>
+                  ),
+                  lastSignInTime: (item: AuthUserSummary) => (
+                    <td>
+                      <small>{formatDate(item.lastSignInTime)}</small>
+                    </td>
+                  ),
+                  actions: (item: AuthUserSummary) => (
+                    <td>
+                      <CButton
+                        color="primary"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleOpenLinkModal(item)}
+                        disabled={!!item.linkedCid || item.isAdmin}
+                        title={
+                          item.isAdmin
+                            ? 'This UID belongs to an admin account'
+                            : item.linkedCid
+                              ? 'Already linked'
+                              : 'Link this UID to a client'
+                        }
+                      >
+                        <CIcon icon={cilLinkAlt} className="me-1" />
+                        Link
+                      </CButton>
+                    </td>
+                  ),
+                }}
+              />
+            )}
+          </CCardBody>
+        </CCard>
+      </CCol>
+
+      <CModal
+        visible={showLinkModal}
+        onClose={() => (linkLoading ? undefined : setShowLinkModal(false))}
+        size="lg"
+      >
+        <CModalHeader>
+          <CModalTitle>Link Firebase UID to Client</CModalTitle>
+        </CModalHeader>
+        <CModalBody>
+          {modalError && <CAlert color="danger">{modalError}</CAlert>}
+
+          {activeUser && (
+            <>
+              <CInputGroup className="mb-2">
+                <CInputGroupText>UID</CInputGroupText>
+                <CFormInput value={activeUser.uid} disabled />
+              </CInputGroup>
+              <CInputGroup className="mb-2">
+                <CInputGroupText>Email</CInputGroupText>
+                <CFormInput value={activeUser.email ?? ''} disabled />
+              </CInputGroup>
+              {activeUserLinked && (
+                <CAlert color="warning">
+                  This UID is already linked to client {activeUser.linkedCid}.
+                </CAlert>
+              )}
+            </>
+          )}
+
+          <hr />
+
+          <div className="mb-3">
+            <label className="form-label fw-semibold mb-1">
+              Select an unlinked client
+            </label>
+            <CFormSelect
+              value={selectedCid}
+              onChange={(e) => {
+                setSelectedCid(e.target.value)
+                if (e.target.value) setManualCid('')
+              }}
+              disabled={linkLoading}
+            >
+              <option value="">-- Choose a client --</option>
+              {clientOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </CFormSelect>
+            <small className="text-muted">
+              Showing {clientOptions.length} client record
+              {clientOptions.length === 1 ? '' : 's'} without a linked UID.
+            </small>
+          </div>
+
+          <div className="mb-1">
+            <label className="form-label fw-semibold mb-1">
+              Or enter a client ID manually
+            </label>
+            <CFormInput
+              value={manualCid}
+              placeholder="e.g. 12345678"
+              onChange={(e) => {
+                setManualCid(e.target.value)
+                if (e.target.value) setSelectedCid('')
+              }}
+              disabled={linkLoading}
+            />
+            <small className="text-muted">
+              Overrides the dropdown when filled. The CID must match an existing client
+              document.
+            </small>
+          </div>
+        </CModalBody>
+        <CModalFooter>
+          <CButton
+            color="secondary"
+            onClick={() => setShowLinkModal(false)}
+            disabled={linkLoading}
+          >
+            Cancel
+          </CButton>
+          <CLoadingButton
+            color="primary"
+            loading={linkLoading}
+            onClick={handleConfirmLink}
+            disabled={!activeUser || activeUserLinked}
+          >
+            <CIcon icon={cilLinkAlt} className="me-1" />
+            Link Account
+          </CLoadingButton>
+        </CModalFooter>
+      </CModal>
+    </CRow>
+  )
+}
+
+export default UserLinks

--- a/src/views/dashboard/ClientTable.tsx
+++ b/src/views/dashboard/ClientTable.tsx
@@ -7,14 +7,16 @@ import { DeleteClient } from './DeleteClient';
 import { EditClient } from './EditClient';
 import ImportClients from './ImportClients';
 import { UnlinkClient } from './UnlinkClient';
+import { LinkClient } from './LinkClient';
 import SendInviteModal from './SendInviteModal';
-import { cilCheckCircle, cilCloudDownload, cilXCircle, cilEnvelopeClosed } from '@coreui/icons';
+import { cilCheckCircle, cilCloudDownload, cilLinkAlt, cilXCircle, cilEnvelopeClosed } from '@coreui/icons';
 import CIcon from '@coreui/icons-react';
 import { usePermissions } from '../../contexts/PermissionContext';
 
 const ClientsTable = () => {
-    const { canWrite, admin, adminService } = usePermissions();
+    const { canWrite, isAdmin, admin, adminService } = usePermissions();
     const [showUnlinkClientModal, setShowUnlinkClientModal] = useState(false);
+    const [showLinkClientModal, setShowLinkClientModal] = useState(false);
     const [showImportClientsModal, setShowImportClientsModal] = useState(false);
     const [showCreateNewClientModal, setShowCreateNewClientModal] = useState(false);
     const [showDisplayDetailsModal, setShowDisplayDetailsModal] = useState(false);
@@ -222,6 +224,7 @@ const ClientsTable = () => {
     return (
         <CContainer>
             {showUnlinkClientModal && <UnlinkClient showModal={showUnlinkClientModal} setShowModal={setShowUnlinkClientModal} client={currentClient} setClients={setClients}/>}
+            {showLinkClientModal && <LinkClient showModal={showLinkClientModal} setShowModal={setShowLinkClientModal} client={currentClient} setClients={setClients}/>}
             {showImportClientsModal && <ImportClients showModal={showImportClientsModal} setShowModal={setShowImportClientsModal} clients={clients}/>}
             {showEditClientModal && <EditClient showModal={showEditClientModal} setShowModal={setShowEditClientModal} clients={clients} setClients={setClients} activeClient={currentClient}/>}
             {showDisplayDetailsModal && <DisplayClient showModal={showDisplayDetailsModal} setShowModal={setShowDisplayDetailsModal} clients={clients} currentClient={currentClient ?? emptyClient}/>}
@@ -311,18 +314,35 @@ const ClientsTable = () => {
                                     </CButton>
                                 </CCol>
                                 <CCol className="text-center">
-                                    <CButton 
-                                        size="sm" 
-                                        color="primary" 
-                                        className="ml-1" 
-                                        variant="outline"
-                                        disabled={!canWrite}
-                                        onClick={() => {
-                                            setShowUnlinkClientModal(true);
-                                            setCurrentClient(clients.find(client => client.cid === item.cid))
-                                        }}>
-                                        Unlink Client 
-                                    </CButton>
+                                    {item.linked ? (
+                                        <CButton 
+                                            size="sm" 
+                                            color="primary" 
+                                            className="ml-1" 
+                                            variant="outline"
+                                            disabled={!canWrite}
+                                            onClick={() => {
+                                                setShowUnlinkClientModal(true);
+                                                setCurrentClient(clients.find(client => client.cid === item.cid))
+                                            }}>
+                                            Unlink Client 
+                                        </CButton>
+                                    ) : (
+                                        <CButton 
+                                            size="sm" 
+                                            color="success" 
+                                            className="ml-1" 
+                                            variant="outline"
+                                            disabled={!canWrite || !isAdmin}
+                                            title={!isAdmin ? 'Admin permission required to link an account' : 'Link a Firebase Auth account to this client'}
+                                            onClick={() => {
+                                                setShowLinkClientModal(true);
+                                                setCurrentClient(clients.find(client => client.cid === item.cid))
+                                            }}>
+                                            <CIcon icon={cilLinkAlt} className="me-1" />
+                                            Link Client
+                                        </CButton>
+                                    )}
                                 </CCol>
                                 <CCol className="text-center">
                                     <CButton 

--- a/src/views/dashboard/LinkClient.tsx
+++ b/src/views/dashboard/LinkClient.tsx
@@ -1,0 +1,249 @@
+import {
+  CAlert,
+  CButton,
+  CFormInput,
+  CInputGroup,
+  CInputGroupText,
+  CLoadingButton,
+  CModal,
+  CModalBody,
+  CModalFooter,
+  CModalHeader,
+  CModalTitle,
+  CMultiSelect,
+  CSpinner,
+} from '@coreui/react-pro'
+import type { Option } from '@coreui/react-pro/dist/esm/components/multi-select/types'
+import { useEffect, useMemo, useState } from 'react'
+import { Client, DatabaseService } from 'src/db/database'
+import { usePermissions } from '../../contexts/PermissionContext'
+import { AuthUserSummary } from '../../db/adminService'
+
+interface LinkClientProps {
+  showModal: boolean
+  setShowModal: (show: boolean) => void
+  client?: Client
+  setClients: (clients: Client[]) => void
+}
+
+const buildUidLabel = (u: AuthUserSummary): string => {
+  const email = u.email || 'no email'
+  const name = u.displayName ? ` · ${u.displayName}` : ''
+  return `${email}${name} — ${u.uid}`
+}
+
+export const LinkClient: React.FC<LinkClientProps> = ({
+  showModal,
+  setShowModal,
+  client,
+  setClients,
+}) => {
+  const { adminService, admin } = usePermissions()
+
+  const [loadingUsers, setLoadingUsers] = useState(false)
+  const [unlinkedUsers, setUnlinkedUsers] = useState<AuthUserSummary[]>([])
+  const [selectedUid, setSelectedUid] = useState('')
+  const [manualUid, setManualUid] = useState('')
+  const [error, setError] = useState('')
+  const [isLinking, setIsLinking] = useState(false)
+  const [selectKey, setSelectKey] = useState(0)
+
+  const loadUnlinkedUsers = async () => {
+    try {
+      setLoadingUsers(true)
+      setError('')
+      const { users } = await adminService.listAuthUsers()
+      const unlinked = users.filter((u) => !u.linkedCid && !u.isAdmin)
+      unlinked.sort((a, b) => {
+        const ae = (a.email || '').toLowerCase()
+        const be = (b.email || '').toLowerCase()
+        return ae.localeCompare(be)
+      })
+      setUnlinkedUsers(unlinked)
+    } catch (err: any) {
+      console.error('Error loading unlinked auth users:', err)
+      setError(err?.message || 'Failed to load Firebase Auth users')
+    } finally {
+      setLoadingUsers(false)
+    }
+  }
+
+  useEffect(() => {
+    if (showModal) {
+      setSelectedUid('')
+      setManualUid('')
+      setError('')
+      setSelectKey((k) => k + 1)
+      loadUnlinkedUsers()
+    }
+  }, [showModal])
+
+  const baseOptions = useMemo<Option[]>(
+    () =>
+      unlinkedUsers.map((u) => ({
+        value: u.uid,
+        label: buildUidLabel(u),
+      })),
+    [unlinkedUsers],
+  )
+
+  const options = useMemo<Option[]>(
+    () =>
+      baseOptions.map((opt) => ({
+        ...opt,
+        selected: opt.value === selectedUid,
+      })),
+    [baseOptions, selectedUid],
+  )
+
+  const linkClient = async () => {
+    if (!client?.cid) {
+      setError('Missing client information.')
+      return
+    }
+    const uid = (manualUid.trim() || selectedUid).trim()
+    if (!uid) {
+      setError('Please choose a Firebase user or enter a UID.')
+      return
+    }
+
+    setIsLinking(true)
+    setError('')
+    try {
+      await adminService.linkAuthUserToClient(uid, client.cid)
+      const service = new DatabaseService()
+      if (admin) service.setCurrentAdmin(admin)
+      const updatedClients = await service.getClients()
+      setClients(updatedClients)
+      setShowModal(false)
+    } catch (err: any) {
+      console.error('Error linking client:', err)
+      const message =
+        err?.message?.replace(/^FirebaseError:\s*/, '') ||
+        'Failed to link this UID to the client.'
+      setError(message)
+    } finally {
+      setIsLinking(false)
+    }
+  }
+
+  const alreadyLinked = !!client?.uid && client.uid !== ''
+
+  return (
+    <CModal
+      scrollable
+      alignment="center"
+      visible={showModal}
+      backdrop="static"
+      size="lg"
+      onClose={() => (isLinking ? undefined : setShowModal(false))}
+    >
+      <CModalHeader>
+        <CModalTitle>Link Firebase User to Client</CModalTitle>
+      </CModalHeader>
+      <CModalBody className="px-4">
+        <p className="mb-3">
+          Link a Firebase Auth account to{' '}
+          <strong>
+            {client?.firstName} {client?.lastName}
+          </strong>{' '}
+          (CID {client?.cid}). This will set the client&rsquo;s UID and email and finish the
+          sign-up flow that the mobile app was supposed to complete.
+        </p>
+
+        {alreadyLinked && (
+          <CAlert color="warning">
+            This client is already linked to UID <code>{client?.uid}</code>. Unlink them
+            first if you need to attach a different account.
+          </CAlert>
+        )}
+        {error && <CAlert color="danger">{error}</CAlert>}
+
+        <CInputGroup className="mb-2">
+          <CInputGroupText>Client</CInputGroupText>
+          <CFormInput
+            value={`${client?.firstName ?? ''} ${client?.lastName ?? ''} (${client?.cid ?? ''})`}
+            disabled
+          />
+        </CInputGroup>
+        <CInputGroup className="mb-3">
+          <CInputGroupText>Client Email</CInputGroupText>
+          <CFormInput value={client?.initEmail || ''} disabled />
+        </CInputGroup>
+
+        <hr />
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold mb-1">
+            Search and select an unlinked Firebase user
+          </label>
+          {loadingUsers ? (
+            <div className="text-center py-3">
+              <CSpinner color="primary" size="sm" />
+              <span className="ms-2 text-muted">Loading Firebase Auth users…</span>
+            </div>
+          ) : (
+            <CMultiSelect
+              key={selectKey}
+              options={options}
+              multiple={false}
+              cleaner
+              search
+              virtualScroller
+              placeholder="Type an email or UID to search..."
+              searchNoResultsLabel={
+                unlinkedUsers.length === 0
+                  ? 'No unlinked Firebase users found'
+                  : 'No matching users'
+              }
+              disabled={isLinking || alreadyLinked}
+              onChange={(selected) => {
+                const value = (selected[0]?.value as string | undefined) ?? ''
+                setSelectedUid(value)
+                if (value) setManualUid('')
+              }}
+            />
+          )}
+          <small className="text-muted">
+            Showing {unlinkedUsers.length} Firebase Auth account
+            {unlinkedUsers.length === 1 ? '' : 's'} without a linked client.
+          </small>
+        </div>
+
+        <div className="mb-1">
+          <label className="form-label fw-semibold mb-1">Or enter a UID manually</label>
+          <CFormInput
+            value={manualUid}
+            placeholder="Firebase Auth UID"
+            onChange={(e) => {
+              setManualUid(e.target.value)
+              if (e.target.value) setSelectedUid('')
+            }}
+            disabled={isLinking || alreadyLinked}
+          />
+          <small className="text-muted">
+            Overrides the dropdown when filled. Useful when the UID is known but not in
+            the unlinked list.
+          </small>
+        </div>
+      </CModalBody>
+      <CModalFooter>
+        <CButton
+          color="secondary"
+          onClick={() => setShowModal(false)}
+          disabled={isLinking}
+        >
+          Cancel
+        </CButton>
+        <CLoadingButton
+          color="primary"
+          loading={isLinking}
+          onClick={linkClient}
+          disabled={alreadyLinked || (!selectedUid && !manualUid.trim())}
+        >
+          Link Account
+        </CLoadingButton>
+      </CModalFooter>
+    </CModal>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new admin-portal page that an administrator can use to finish a mobile sign-up link manually when the mobile app&rsquo;s `linkNewUser` API call never landed. This fixes the bug where users end up with a Firebase Auth account but no linked client document, which puts the mobile app into an infinite loop and forces someone to intervene in the Firebase console.

## What&rsquo;s new

### Sidebar navigation
A new **User Links** entry has been added between *Statements* and *Admin Management* (icon: link). It routes to `/user-links`.

### New page: `src/views/admin/UserLinks.tsx`
- Lists every user in Firebase Authentication with UID, email, provider, created / last sign-in times, and a status badge (`Linked`, `Unlinked`, `Admin`).
- Defaults to showing only **Unlinked** users (i.e. the ones causing problems); the dropdown also exposes *Linked clients*, *Admins*, and *All users*.
- Per-row **Link** button opens a modal that lets the admin either
  - pick an unlinked client from a dropdown (`CID — First Last (email)`), or
  - enter a client ID manually (takes precedence over the dropdown selection).
- Admin-only; non-admins see an access-denied message (reuses `usePermissions`).

### New Cloud Functions (`functions/src/admin/`)
- `listAuthUsers` &mdash; admin-only callable that pages through all Firebase Auth users via the Admin SDK and cross-references them against the clients collection (and `admins` collection) so the page can flag each UID as linked, unlinked, or an admin account.
- `adminLinkUser` &mdash; admin-only callable that takes a `{ uid, cid }` pair and:
  1. Verifies the Auth user exists (pulls their email from Firebase Auth).
  2. Verifies the client doc exists and isn&rsquo;t already linked to a *different* UID.
  3. Verifies the UID isn&rsquo;t already linked to a *different* client.
  4. Writes `uid`, `email`, `appEmail`, `linked: true`, plus audit fields into the client doc.
  5. Runs `addUidToConnectedUsers(...)` so the user gains read access to any connected users &mdash; same side effect the mobile `linkNewUser` callable performs.

Both are exported from `functions/src/index.ts`.

### Frontend service
`AdminService` gains `listAuthUsers()` and `linkAuthUserToClient(uid, cid)` helpers that wrap the new callables.

## Why a separate `adminLinkUser` rather than reusing `linkNewUser`
The existing `linkNewUser` callable only authenticates the current user via `context.auth` and relies on the caller already being the user being linked; it also hardcodes client-supplied values like `usersCollectionID`. A dedicated admin callable lets us:
- gate access behind `checkAdminPermission(context, 'admin')`,
- pull `email` from Firebase Auth instead of trusting the caller,
- pull `usersCollectionID` from the server-side `config.json`,
- attach proper `updatedBy` / `updatedAt` audit fields.

## Verification
- `npm run build` (vite) &rarr; succeeds; `UserLinks` appears as its own lazy-loaded chunk.
- `npm run build` inside `functions/` &rarr; succeeds.
- `tsc --noEmit` reports the same pre-existing unused-import warnings as `main`; no new type errors were introduced.
- Firebase emulator / live testing was not run in this environment; once deployed, an admin should be able to open **User Links**, pick an unlinked UID, select or enter the target client CID, and hit **Link Account** to complete the flow without Firebase console access.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80d0b2f7-9e97-4a8e-95d6-9ab34637bc57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80d0b2f7-9e97-4a8e-95d6-9ab34637bc57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

