### PR TITLE
Auto-sync config.json into functions/ before tsc build

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "functions",
   "scripts": {
+    "prebuild": "node scripts/sync-config.cjs",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",

--- a/functions/scripts/sync-config.cjs
+++ b/functions/scripts/sync-config.cjs
@@ -1,0 +1,57 @@
+/**
+ * @file sync-config.cjs
+ * @description Copies the workspace-root `config.json` into `functions/`
+ *              so that `tsc` can resolve the `import "../../config.json"`
+ *              statements in the Cloud Functions source.
+ *
+ *              `config.json` is gitignored project-wide because it can
+ *              contain secrets, so each developer keeps a copy at the
+ *              workspace root (the rest of the codebase imports from
+ *              there). This script bridges the gap so that running
+ *              `npm install && npm run deploy` (or `npm run deploy:invite`
+ *              from the root) just works without a manual file copy.
+ *
+ *              Wired up via the `prebuild` script in functions/package.json.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const FUNCTIONS_DIR = path.resolve(__dirname, "..");
+const ROOT_CONFIG = path.resolve(FUNCTIONS_DIR, "..", "config.json");
+const FUNCTIONS_CONFIG = path.resolve(FUNCTIONS_DIR, "config.json");
+const BUILT_CONFIG = path.resolve(FUNCTIONS_DIR, "lib", "config.json");
+
+function tryCopy(src, dst, label) {
+  try {
+    fs.copyFileSync(src, dst);
+    console.log(`[sync-config] copied ${label} -> ${path.relative(FUNCTIONS_DIR, dst)}`);
+    return true;
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw err;
+    }
+    return false;
+  }
+}
+
+if (fs.existsSync(ROOT_CONFIG)) {
+  tryCopy(ROOT_CONFIG, FUNCTIONS_CONFIG, "../config.json");
+} else if (fs.existsSync(FUNCTIONS_CONFIG)) {
+  console.log(
+    "[sync-config] root config.json not found; using existing functions/config.json"
+  );
+} else if (fs.existsSync(BUILT_CONFIG)) {
+  tryCopy(BUILT_CONFIG, FUNCTIONS_CONFIG, "lib/config.json");
+} else {
+  console.error(
+    [
+      "[sync-config] FATAL: no config.json found at any of:",
+      `  - ${ROOT_CONFIG}`,
+      `  - ${FUNCTIONS_CONFIG}`,
+      `  - ${BUILT_CONFIG}`,
+      "Create config.json at the workspace root before building.",
+    ].join("\n")
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Trying to deploy Cloud Functions from a freshly-cloned repo fails on `tsc`:

```
src/admin/adminLinkUser.ts:15:20 - error TS2307:
  Cannot find module '../../config.json' or its corresponding type declarations.
```

The Functions code imports from `../../config.json` (i.e. expects `functions/config.json`), but `config.json` is gitignored project-wide and only lives at the workspace root. Until now, every developer had to remember to manually copy the root `config.json` into `functions/` before any build or deploy.

## Fix

Adds a small Node script at `functions/scripts/sync-config.cjs` that copies the workspace-root `config.json` into `functions/config.json` (with fallbacks to an existing `functions/config.json` or `functions/lib/config.json` if the root file is missing), and wires it up as a `prebuild` script in `functions/package.json` so it runs automatically before `tsc`.

The script prints a clear, actionable message and exits non-zero if no `config.json` is reachable anywhere, so the failure mode for completely-missing config is still loud.

After this change, both `cd functions && npm run deploy` and `npm run deploy:invite` (from the workspace root) work without any manual setup.

## Verification

Reproduced the failure by deleting `functions/config.json`, then ran `npm run build` from `functions/`:

```
> prebuild
> node scripts/sync-config.cjs

[sync-config] copied ../config.json -> config.json

> build
> tsc
```

`tsc` then completes cleanly.

## No runtime / template impact

This is a build-time-only change. No source files in `functions/src/` are modified, no Cloud Function behavior changes, and no email content changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

