### PR TITLE
Polish invite email visuals: center logo + defeat Outlook auto-invert

### DIFF
--- a/functions/src/emails/InviteEmail.tsx
+++ b/functions/src/emails/InviteEmail.tsx
@@ -50,18 +50,35 @@ export interface InviteEmailProps {
   supportEmail: string;
 }
 
+/*
+ * Color palette.
+ *
+ * IMPORTANT: the panel / CID / note background colors are intentionally
+ * pushed slightly more saturated than a typical "near-white tint" (e.g.
+ * #ebeff5 instead of #f8f9fa). This is because Outlook 365 webmail and
+ * "New Outlook for Windows" (Webview2 / Edge engine) run an automatic
+ * color adjustment that inverts colors it considers to be "page
+ * background tint" - which catches near-white tinted colors like
+ * #f8f9fa, #fff8e1, and #eef2f8 - while leaving pure #ffffff cards
+ * and saturated brand colors alone.
+ *
+ * By moving the panel colors a few percent further from white, Outlook
+ * treats them as intentional design colors and renders them as-is.
+ * The colors still read as subtle "layered" panels in Apple Mail /
+ * Gmail, matching the intended visual hierarchy.
+ */
 const COLORS = {
   primary: "#0a3464",
   primaryDark: "#082849",
   text: "#3e3e3e",
   mutedText: "#5a5a5a",
   pageBg: "#f5f5f5",
-  panelBg: "#f8f9fa",
+  panelBg: "#ebeff5",
   cardBg: "#ffffff",
-  border: "#e2e6ea",
-  warningBg: "#fff8e1",
-  warningBorder: "#d4a017",
-  cidBg: "#eef2f8",
+  border: "#d8dde4",
+  warningBg: "#fde9b3",
+  warningBorder: "#c89009",
+  cidBg: "#d4e0f2",
 };
 
 const FONT_BODY =
@@ -295,6 +312,23 @@ const HEAD_CSS = `
   [data-ogsb] .agq-text-primary {
     color: ${COLORS.primary} !important;
   }
+
+  /*
+   * Always-on color enforcement (light mode AND dark mode).
+   *
+   * Outlook 365 webmail and "New Outlook for Windows" run an automatic
+   * color adjustment that can re-tint or invert background colors even
+   * when the UI is in light mode (it reacts to the *system* color
+   * scheme, not the Outlook UI preference). The rules below set our
+   * intended palette with !important at the top of the cascade, so
+   * even when Outlook applies its own inline overrides, ours win.
+   *
+   * Pure-white step cards and pure-navy header/footer are always
+   * preserved by Outlook untouched, so they do not need a rule here.
+   */
+  td.agq-panel { background-color: ${COLORS.panelBg} !important; }
+  td.agq-cid { background-color: ${COLORS.cidBg} !important; }
+  td.agq-note { background-color: ${COLORS.warningBg} !important; }
 
   /* Apple / iOS Mail: opt every panel out of color-scheme inversion. */
   :root {

--- a/functions/src/emails/InviteEmail.tsx
+++ b/functions/src/emails/InviteEmail.tsx
@@ -462,22 +462,51 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                   <span
                     dangerouslySetInnerHTML={{ __html: HEADER_VML_OPEN }}
                   />
-                  <Img
-                    src={`cid:${logoCid}`}
-                    alt="AGQ"
-                    width="160"
-                    height="101"
+                  {/*
+                    Logo is wrapped in its own centered table because some
+                    email clients (notably Apple Mail and Gmail web) strip
+                    `margin: 0 auto` from a `display: block` <img>, leaving
+                    the image left-aligned inside the header. Wrapping it
+                    in a `<table align="center">` is the bulletproof
+                    centering pattern: the table itself is a block-level
+                    element that gets horizontally centered by its parent's
+                    `align="center"` / `text-align: center`, and the image
+                    inside it stays its natural size. Works in every
+                    client, including Outlook.
+                  */}
+                  <table
+                    role="presentation"
+                    align="center"
+                    cellPadding={0}
+                    cellSpacing={0}
+                    border={0}
                     style={{
-                      display: "block",
+                      borderCollapse: "collapse",
                       margin: "0 auto",
-                      width: 160,
-                      height: "auto",
-                      maxWidth: 160,
-                      border: 0,
-                      outline: "none",
-                      textDecoration: "none",
                     }}
-                  />
+                  >
+                    <tbody>
+                      <tr>
+                        <td align="center" style={{ textAlign: "center" }}>
+                          <Img
+                            src={`cid:${logoCid}`}
+                            alt="AGQ"
+                            width="160"
+                            height="101"
+                            style={{
+                              display: "block",
+                              width: 160,
+                              height: 101,
+                              maxWidth: 160,
+                              border: 0,
+                              outline: "none",
+                              textDecoration: "none",
+                            }}
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
                   <Heading
                     as="h1"
                     className="agq-text-light"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Two visual fixes for the invite email

### 1. Center the AGQ logo (Apple Mail / Gmail web)

After the dark-mode hardening landed, the logo in the navy header rendered off-center to the left on Apple Mail and Gmail web. The heading text below it stayed correctly centered.

**Root cause:** the `<Img>` was relying on `display: block; margin: 0 auto` for centering. Apple Mail and Gmail web both sanitize away `margin: auto` on a block-level `<img>` in some contexts, leaving the image at its default left alignment.

**Fix:** wraps the logo in a centered inner table — the bulletproof email centering pattern:

```html
<table align="center" style="margin:0 auto">
  <tr>
    <td align="center" style="text-align:center">
      <img ... />
    </td>
  </tr>
</table>
```

The wrapper table is a block-level element that gets horizontally centered by the parent's `align="center"` / `text-align: center` (HTML attribute and CSS — neither of which any client strips). The image inside it stays its natural size. Works in every client.

### 2. Defeat Outlook's auto-invert of near-white panel colors

After deploying, the email rendered correctly on Outlook **dark mode** but on Outlook **light mode** the steps panel, the Important callout, the CID box, and the support/signature panels all came out as inverted dark colors — while the white step cards, the navy header/footer, and the page background all stayed correct.

**Root cause:** Outlook 365 webmail and "New Outlook for Windows" (Webview2 / Edge engine) run an automatic color adjustment that inverts colors it considers "page background tint." This catches near-white tinted colors like `#f8f9fa`, `#fff8e1`, and `#eef2f8`, while leaving pure `#ffffff` cards and saturated brand colors alone. The adjustment fires based on the *system* color scheme, not Outlook's UI preference, so users with Outlook in light mode but their OS in dark mode get hit.

The `color-scheme: light only` meta tag and the `[data-ogsc]` / `[data-ogsb]` dark-mode override selectors don't help here because Outlook's auto-color-adjust runs as a separate pipeline.

**Fix:** push the panel / CID / note background colors slightly out of the "near-white" range, and add top-level `!important` rules in `<style>`:

| Token | Before | After |
| --- | --- | --- |
| `panelBg` | `#f8f9fa` | `#ebeff5` |
| `cidBg` | `#eef2f8` | `#d4e0f2` |
| `warningBg` | `#fff8e1` | `#fde9b3` |
| `warningBorder` | `#d4a017` | `#c89009` |
| `border` | `#e2e6ea` | `#d8dde4` |

These are still subtle enough to read as "layered panels" in Apple Mail / Gmail (matching the intended look in the user's reference screenshot), but saturated enough that Outlook treats them as intentional design colors instead of page-background-to-be-inverted.

The new top-level `<style>` rules:

```css
td.agq-panel { background-color: #ebeff5 !important; }
td.agq-cid   { background-color: #d4e0f2 !important; }
td.agq-note  { background-color: #fde9b3 !important; }
```

force the colors with `!important` specificity, so even if Outlook applies its own inline overrides, ours win.

Pure-white step cards and pure-navy header/footer don't need rules — those colors are never inverted by Outlook regardless.

## Verification

- `npm run build` (in `functions/`) compiles cleanly.
- Re-rendered the template and screenshotted in headless Chromium. Logo is now visually centered above the heading text, and the panel colors render as a soft layered hierarchy: subtle blue-gray steps panel → white step cards → light blue CID box / warm yellow Important callout → blue-gray support and signature panels → navy footer. Visually matches the intended Apple Mail look closely.
- Outlook dark-mode hardening (VML rectangles, `bgcolor=""` attributes, `[data-ogsc]` selectors, light-mode lock) is unchanged.

## Files changed

- `functions/src/emails/InviteEmail.tsx`

## Deploy

After merge, redeploy with `npm run deploy:invite` from the workspace root.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

