### PR TITLE
Deploy Firebase Functions on merge to main

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase Hosting on merge
+name: Deploy to Firebase on merge
 on:
   push:
     branches:
@@ -8,8 +8,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm ci && npm run build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Build hosting
+        run: npm ci && npm run build
+
+      - name: Install functions dependencies
+        run: npm install --prefix functions
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TEAM_SHAIKH_APP_52DC5 }}
+
+      - name: Deploy Firebase Functions
+        run: npx --yes firebase-tools deploy --only functions --project team-shaikh-app-52dc5 --non-interactive
+
+      - name: Deploy Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TEAM_SHAIKH_APP_52DC5 }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the main-branch Firebase workflow to deploy Cloud Functions alongside Hosting when code is merged to `main`.

## Changes

- Renamed workflow to **Deploy to Firebase on merge**
- Added Node 22 setup (matches `functions/package.json` engines)
- Install functions dependencies before deploy
- Authenticate with the existing `FIREBASE_SERVICE_ACCOUNT_TEAM_SHAIKH_APP_52DC5` secret
- Run `firebase deploy --only functions` (uses `firebase.json` predeploy to build TypeScript)
- Keep the existing Hosting deploy step unchanged

## IAM note

If the first functions deploy fails with a permissions error, the Firebase service account may need these roles in Google Cloud IAM:

- **Cloud Functions Admin**
- **Service Account User** (often required for function runtime identity)

The Hosting-only setup from `firebase init hosting` does not always grant functions deploy permissions by default.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e14bf47-681b-404d-99cd-d21a7d45b025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e14bf47-681b-404d-99cd-d21a7d45b025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

