### PR TITLE
Match invite email copy to admin's text template

### DIFF
--- a/functions/src/emails/InviteEmail.tsx
+++ b/functions/src/emails/InviteEmail.tsx
@@ -158,6 +158,19 @@ const styles = {
     textDecoration: "underline",
     wordBreak: "break-all" as const,
   } as React.CSSProperties,
+  inlineLink: {
+    color: COLORS.primary,
+    fontWeight: 700,
+    textDecoration: "underline",
+  } as React.CSSProperties,
+  cidNote: {
+    fontSize: 13,
+    lineHeight: "18px",
+    color: COLORS.mutedText,
+    fontStyle: "italic" as const,
+    textAlign: "center" as const,
+    margin: "10px 0 0 0",
+  } as React.CSSProperties,
   noteText: {
     fontSize: 14,
     lineHeight: "20px",
@@ -574,15 +587,17 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                     Dear {firstName},
                   </Text>
                   <Text className="agq-text-dark" style={styles.paragraph}>
-                    We hope this message finds you well. AGQ is pleased to
-                    invite you to access your investment portfolio through our
-                    secure mobile application.
+                    We hope this message finds you well.
                   </Text>
                   <Text className="agq-text-dark" style={styles.paragraph}>
-                    With this app, you can conveniently monitor your up-to-date
-                    investment information, track performance, and stay
-                    connected with your financial growth&mdash;all from your
-                    mobile device.
+                    We&rsquo;re excited to get you set up on the AGQ
+                    App&mdash;your personal, real-time view of your investment
+                    portfolio, available anytime directly from your phone.
+                  </Text>
+                  <Text className="agq-text-dark" style={styles.paragraph}>
+                    This is a quick, one-time setup that takes just a few
+                    minutes. Follow the four steps below and you&rsquo;ll be
+                    all set.
                   </Text>
                 </td>
               </tr>
@@ -628,46 +643,38 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                             padding: "24px",
                           }}
                         >
-                          <Heading
-                            as="h2"
-                            className="agq-text-dark"
-                            style={styles.stepsTitle}
-                          >
-                            Getting Started &mdash; Three Simple Steps
-                          </Heading>
-
-                          {/* STEP 1 */}
+                          {/* STEP 1 - Download the AGQ App */}
                           <StepCard>
                             <StepHeaderRow
                               digit="1"
-                              title="Download the Application"
+                              title="Download the AGQ App"
                             />
                             <Text
                               className="agq-text-dark"
-                              style={styles.downloadLabel}
+                              style={styles.stepBodyText}
                             >
-                              For iOS Users:
+                              For Apple users click{" "}
+                              <Link
+                                href={iosLink}
+                                className="agq-text-primary"
+                                style={styles.inlineLink}
+                              >
+                                Here
+                              </Link>
                             </Text>
-                            <Link
-                              href={iosLink}
-                              className="agq-text-primary"
-                              style={styles.downloadLink}
-                            >
-                              {iosLink}
-                            </Link>
                             <Text
                               className="agq-text-dark"
-                              style={styles.downloadLabel}
+                              style={styles.stepBodyText}
                             >
-                              For Android Users:
+                              For Android users click{" "}
+                              <Link
+                                href={androidLink}
+                                className="agq-text-primary"
+                                style={styles.inlineLink}
+                              >
+                                Here
+                              </Link>
                             </Text>
-                            <Link
-                              href={androidLink}
-                              className="agq-text-primary"
-                              style={styles.downloadLink}
-                            >
-                              {androidLink}
-                            </Link>
                             <NoteBox>
                               <Text
                                 className="agq-text-dark"
@@ -677,21 +684,45 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                                   className="agq-text-primary"
                                   style={{ color: COLORS.primary }}
                                 >
-                                  Important:
+                                  Important Note:
                                 </strong>{" "}
-                                The application is exclusively available on
-                                mobile devices. Please open the download links
-                                directly on your smartphone or tablet.
+                                The app is only available on mobile devices.
+                                The download links must be opened on a mobile
+                                device to install the app.
                               </Text>
                             </NoteBox>
                           </StepCard>
 
-                          {/* STEP 2 */}
+                          {/* STEP 2 - Create Your Account */}
                           <StepCard>
                             <StepHeaderRow
                               digit="2"
-                              title="Enter Your Client Identification Number"
+                              title="Create Your Account"
                             />
+                            <Text
+                              className="agq-text-dark"
+                              style={styles.stepBodyText}
+                            >
+                              Once installed, open the app and tap{" "}
+                              <strong>&ldquo;Create Account.&rdquo;</strong>{" "}
+                              Enter your email address and choose a password.
+                            </Text>
+                          </StepCard>
+
+                          {/* STEP 3 - Enter Your Client ID */}
+                          <StepCard>
+                            <StepHeaderRow
+                              digit="3"
+                              title="Enter Your Client ID (CID)"
+                            />
+                            <Text
+                              className="agq-text-dark"
+                              style={styles.stepBodyText}
+                            >
+                              When prompted, enter the Client ID
+                              below&mdash;this links your account to your
+                              portfolio.
+                            </Text>
                             <table
                               role="presentation"
                               width="100%"
@@ -735,23 +766,31 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                                 </tr>
                               </tbody>
                             </table>
+                            <Text style={styles.cidNote}>
+                              This is your unique 8-digit identifier. Please
+                              keep it confidential.
+                            </Text>
                           </StepCard>
 
-                          {/* STEP 3 */}
+                          {/* STEP 4 - Finish & Log In */}
                           <StepCard last>
                             <StepHeaderRow
-                              digit="3"
-                              title="Complete Account Setup"
+                              digit="4"
+                              title="Finish & Log In"
                             />
                             <Text
                               className="agq-text-dark"
                               style={styles.stepBodyText}
                             >
-                              Follow the guided instructions to create your
-                              secure account using your email address and
-                              Client ID. This is a one-time setup
-                              process&mdash;your CID will not be required for
-                              future logins.
+                              Follow the final prompts to complete setup. This
+                              only needs to be done once.
+                            </Text>
+                            <Text
+                              className="agq-text-dark"
+                              style={styles.stepBodyText}
+                            >
+                              Going forward, open the app and log in with your
+                              email and password anytime.
                             </Text>
                           </StepCard>
                         </td>
@@ -803,19 +842,10 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                         >
                           <Text
                             className="agq-text-dark"
-                            style={styles.supportText}
-                          >
-                            Our platform is designed with simplicity and
-                            security in mind. Should you require any assistance
-                            during the setup process or have questions about
-                            your account, our dedicated support team is readily
-                            available.
-                          </Text>
-                          <Text
-                            className="agq-text-dark"
                             style={styles.supportContact}
                           >
-                            <strong>Contact Support:</strong>{" "}
+                            Have a question or need help? Our support team is
+                            happy to assist&mdash;email us anytime at{" "}
                             <Link
                               href={`mailto:${supportEmail}`}
                               className="agq-text-primary"
@@ -827,6 +857,7 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
                             >
                               {supportEmail}
                             </Link>
+                            {" "}and we&rsquo;ll get back to you promptly.
                           </Text>
                         </td>
                       </tr>
@@ -848,62 +879,10 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
           >
             <tbody>
               <tr>
-                <td style={styles.contentPadding}>
+                <td style={{ padding: "32px 32px 32px 32px" }}>
                   <Text className="agq-text-dark" style={styles.paragraph}>
-                    Thank you for your continued trust in AGQ. We are excited
-                    to provide you with enhanced accessibility and a more
-                    streamlined experience through this mobile platform.
+                    Thank you for your continued trust in our team.
                   </Text>
-                </td>
-              </tr>
-              <tr>
-                <td style={{ padding: "16px 32px 32px 32px" }}>
-                  <table
-                    role="presentation"
-                    width="100%"
-                    cellPadding={0}
-                    cellSpacing={0}
-                    border={0}
-                    {...bgcolorProps(COLORS.panelBg)}
-                    style={{
-                      borderCollapse: "collapse",
-                      backgroundColor: COLORS.panelBg,
-                      border: `1px solid ${COLORS.border}`,
-                      borderRadius: 8,
-                    }}
-                  >
-                    <tbody>
-                      <tr>
-                        <td
-                          {...bgcolorProps(COLORS.panelBg)}
-                          className="agq-panel"
-                          style={{
-                            backgroundColor: COLORS.panelBg,
-                            padding: "18px 20px",
-                          }}
-                        >
-                          <Text
-                            className="agq-text-dark"
-                            style={styles.signatureItalic}
-                          >
-                            With humility and continued gratitude,
-                          </Text>
-                          <Text
-                            className="agq-text-dark"
-                            style={styles.signatureName}
-                          >
-                            Sonny and Kash Shaikh
-                          </Text>
-                          <Text
-                            className="agq-text-dark"
-                            style={styles.signatureTeam}
-                          >
-                            AGQ Team
-                          </Text>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin sent over a new text template for the invite email and asked us to match it. This PR rewrites the body copy of `functions/src/emails/InviteEmail.tsx` accordingly, while preserving the existing visual styling (navy header / footer, panel layering, rounded step cards, CID box, yellow callout, etc.).

The biggest structural change is that the email is now **four steps** instead of three — there's a new "Create Your Account" step inserted between "Download" and "Enter CID."

## Discrepancies fixed

| # | Section | Before | After (matches admin's template) |
|---|---|---|---|
| 1 | Intro paragraph 1 | "We hope this message finds you well. AGQ is pleased to invite you to access your investment portfolio through our secure mobile application." | "We hope this message finds you well." |
| 2 | Intro paragraph 2 | "With this app, you can conveniently monitor your up-to-date investment information, track performance, and stay connected with your financial growth—all from your mobile device." | "We're excited to get you set up on the AGQ App—your personal, real-time view of your investment portfolio, available anytime directly from your phone." |
| 3 | Intro paragraph 3 | (none) | "This is a quick, one-time setup that takes just a few minutes. Follow the four steps below and you'll be all set." |
| 4 | Steps heading | "Getting Started — Three Simple Steps" | (removed; cards stand on their own and the count is now four) |
| 5 | Step 1 title | "Download the Application" | "Download the AGQ App" |
| 6 | Step 1 download links | Full URL shown as link on its own line | Inline "For Apple users click **Here**" / "For Android users click **Here**" with "Here" hyperlinked |
| 7 | Step 1 note | "**Important:** The application is exclusively available on mobile devices. Please open the download links directly on your smartphone or tablet." | "**Important Note:** The app is only available on mobile devices. The download links must be opened on a mobile device to install the app." |
| 8 | Step 2 | (was the CID step) | NEW: **Create Your Account** — "Once installed, open the app and tap '**Create Account.**' Enter your email address and choose a password." |
| 9 | Step 3 title | "Enter Your Client Identification Number" | "Enter Your Client ID (CID)" |
| 10 | Step 3 body | (just the CID box) | Body sentence above the box: "When prompted, enter the Client ID below—this links your account to your portfolio." Italic muted note below the box: "This is your unique 8-digit identifier. Please keep it confidential." |
| 11 | Step 4 title | "Complete Account Setup" | "Finish & Log In" |
| 12 | Step 4 body | "Follow the guided instructions to create your secure account using your email address and Client ID. This is a one-time setup process—your CID will not be required for future logins." | Two paragraphs: "Follow the final prompts to complete setup. This only needs to be done once." / "Going forward, open the app and log in with your email and password anytime." |
| 13 | Support panel | "Our platform is designed with simplicity and security in mind. Should you require any assistance during the setup process or have questions about your account, our dedicated support team is readily available. **Contact Support:** management@agqconsulting.com" | "Have a question or need help? Our support team is happy to assist—email us anytime at management@agqconsulting.com and we'll get back to you promptly." |
| 14 | Closing | "Thank you for your continued trust in AGQ. We are excited to provide you with enhanced accessibility and a more streamlined experience through this mobile platform." | "Thank you for your continued trust in our team." |
| 15 | Signature | "With humility and continued gratitude, **Sonny and Kash Shaikh**, AGQ Team" | (removed; admin's template ends after the closing paragraph) |

## Kept as-is (not in admin's template body, but structural / branding)

- The navy header with the AGQ logo + "Welcome to your Investment Management App Invitation" heading. This mirrors the email subject line and is the visual anchor of the message.
- The navy footer with "Planning Today, Securing Tomorrow" tagline, AGQ Consulting LLC, the Lake Mary, FL address, and the support email. Standard brand / legal sign-off; not part of the body copy template.

If the admin wants either of those removed too, easy follow-up.

## Implementation notes

- New `inlineLink` style for the bold underlined primary-color "Here" word inside the Step 1 download lines.
- New `cidNote` style for the small italic muted-gray privacy reminder below the CID box.
- All previous Outlook hardening (VML rectangles, `bgcolor=""` HTML attributes, `[data-ogsc]` / `[data-ogsb]` overrides, `color-scheme: light only` lock, saturated panel colors that defeat Outlook auto-invert) is unchanged.
- The plain-text alternative body (rendered from the same React component via `render(element, { plainText: true })`) automatically reflects the new copy and reads exactly like the admin's template.

## Verification

- `npm run build` (in `functions/`) compiles cleanly.
- Re-rendered both HTML and plain-text outputs and inspected them. Plain text reads through line-by-line as the admin's template.
- Headless Chromium screenshot of the HTML render shows the email matching the new copy: Dear / 3-paragraph intro / 4 numbered step cards / friendlier support panel / one-line closing / footer.

## Files changed

- `functions/src/emails/InviteEmail.tsx`

## Deploy

After merging, the existing GitHub Actions auto-deploy on `main` will redeploy the function. (Or, manually, `npm run deploy:invite` from the workspace root.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

