### PR TITLE
Restore Sonny and Kash Shaikh signature on invite email

### DIFF
--- a/functions/src/emails/InviteEmail.tsx
+++ b/functions/src/emails/InviteEmail.tsx
@@ -879,10 +879,60 @@ export const InviteEmail: React.FC<InviteEmailProps> = ({
           >
             <tbody>
               <tr>
-                <td style={{ padding: "32px 32px 32px 32px" }}>
+                <td style={styles.contentPadding}>
                   <Text className="agq-text-dark" style={styles.paragraph}>
                     Thank you for your continued trust in our team.
                   </Text>
+                </td>
+              </tr>
+              <tr>
+                <td style={{ padding: "16px 32px 32px 32px" }}>
+                  <table
+                    role="presentation"
+                    width="100%"
+                    cellPadding={0}
+                    cellSpacing={0}
+                    border={0}
+                    {...bgcolorProps(COLORS.panelBg)}
+                    style={{
+                      borderCollapse: "collapse",
+                      backgroundColor: COLORS.panelBg,
+                      border: `1px solid ${COLORS.border}`,
+                      borderRadius: 8,
+                    }}
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          {...bgcolorProps(COLORS.panelBg)}
+                          className="agq-panel"
+                          style={{
+                            backgroundColor: COLORS.panelBg,
+                            padding: "18px 20px",
+                          }}
+                        >
+                          <Text
+                            className="agq-text-dark"
+                            style={styles.signatureItalic}
+                          >
+                            With humility and continued gratitude,
+                          </Text>
+                          <Text
+                            className="agq-text-dark"
+                            style={styles.signatureName}
+                          >
+                            Sonny and Kash Shaikh
+                          </Text>
+                          <Text
+                            className="agq-text-dark"
+                            style={styles.signatureTeam}
+                          >
+                            AGQ Team
+                          </Text>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#58](https://github.com/zaminshaikh/agq_admin_portal/pull/58). The admin's text template ended with just "Thank you for your continued trust in our team." with no signature, so #58 removed the signature panel. The user followed up asking for the signature to stay.

This PR adds the signature panel back, exactly as it was before, between the closing paragraph and the navy footer:

```
With humility and continued gratitude,
Sonny and Kash Shaikh
AGQ Team
```

It uses the same blue-gray rounded panel and the existing `signatureItalic` / `signatureName` / `signatureTeam` styles (which were left in place in the styles object after #58, so no new styling needed).

## Files changed

- `functions/src/emails/InviteEmail.tsx`

## Verification

- `npm run build` (in `functions/`) compiles cleanly.
- Re-rendered the React Email template and screenshotted in headless Chromium. The signature panel sits where it did before #58, directly below the "Thank you for your continued trust in our team." closing paragraph and above the navy footer.

## Deploy

After merging, the existing GitHub Actions auto-deploy on `main` will redeploy `sendInviteEmail`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c3050a-b68a-4a38-bee4-a21658023e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

